### PR TITLE
Add buttonmap.xml and topology.xml

### DIFF
--- a/game.libretro.fuse/addon.xml.in
+++ b/game.libretro.fuse/addon.xml.in
@@ -5,6 +5,7 @@
 		provider-name="Libretro">
 	<requires>
 		<import addon="game.libretro" version="1.0.0"/>
+		<import addon="game.controller.atari.2600" version="1.0.0"/>
 	</requires>
 	<extension point="kodi.gameclient"
 			library_@PLATFORM@="@LIBRARY_FILENAME@">

--- a/game.libretro.fuse/resources/buttonmap.xml
+++ b/game.libretro.fuse/resources/buttonmap.xml
@@ -9,16 +9,16 @@
     <feature name="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
   </controller>
   <controller id="game.controller.keyboard" type="RETRO_DEVICE_KEYBOARD" subclass="0">
-    <feature name="one" mapto="RETROK_1"/>
-    <feature name="two" mapto="RETROK_2"/>
-    <feature name="three" mapto="RETROK_3"/>
-    <feature name="four" mapto="RETROK_4"/>
-    <feature name="five" mapto="RETROK_5"/>
-    <feature name="size" mapto="RETROK_6"/>
-    <feature name="seven" mapto="RETROK_7"/>
-    <feature name="eight" mapto="RETROK_8"/>
-    <feature name="nine" mapto="RETROK_9"/>
-    <feature name="zero" mapto="RETROK_0"/>
+    <feature name="1" mapto="RETROK_1"/>
+    <feature name="2" mapto="RETROK_2"/>
+    <feature name="3" mapto="RETROK_3"/>
+    <feature name="4" mapto="RETROK_4"/>
+    <feature name="5" mapto="RETROK_5"/>
+    <feature name="6" mapto="RETROK_6"/>
+    <feature name="7" mapto="RETROK_7"/>
+    <feature name="8" mapto="RETROK_8"/>
+    <feature name="9" mapto="RETROK_9"/>
+    <feature name="0" mapto="RETROK_0"/>
     <feature name="a" mapto="RETROK_a"/>
     <feature name="b" mapto="RETROK_b"/>
     <feature name="c" mapto="RETROK_c"/>

--- a/game.libretro.fuse/resources/buttonmap.xml
+++ b/game.libretro.fuse/resources/buttonmap.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<buttonmap version="2">
+  <controller id="game.controller.atari.2600" type="RETRO_DEVICE_JOYPAD" subclass="0">
+    <feature name="fire" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
+    <!-- TODO: Direction buttons in controller profile -->
+    <feature name="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
+    <feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
+    <feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
+    <feature name="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
+  </controller>
+  <controller id="game.controller.keyboard" type="RETRO_DEVICE_KEYBOARD" subclass="0">
+    <feature name="one" mapto="RETROK_1"/>
+    <feature name="two" mapto="RETROK_2"/>
+    <feature name="three" mapto="RETROK_3"/>
+    <feature name="four" mapto="RETROK_4"/>
+    <feature name="five" mapto="RETROK_5"/>
+    <feature name="size" mapto="RETROK_6"/>
+    <feature name="seven" mapto="RETROK_7"/>
+    <feature name="eight" mapto="RETROK_8"/>
+    <feature name="nine" mapto="RETROK_9"/>
+    <feature name="zero" mapto="RETROK_0"/>
+    <feature name="a" mapto="RETROK_a"/>
+    <feature name="b" mapto="RETROK_b"/>
+    <feature name="c" mapto="RETROK_c"/>
+    <feature name="d" mapto="RETROK_d"/>
+    <feature name="e" mapto="RETROK_e"/>
+    <feature name="f" mapto="RETROK_f"/>
+    <feature name="g" mapto="RETROK_g"/>
+    <feature name="h" mapto="RETROK_h"/>
+    <feature name="i" mapto="RETROK_i"/>
+    <feature name="j" mapto="RETROK_j"/>
+    <feature name="k" mapto="RETROK_k"/>
+    <feature name="l" mapto="RETROK_l"/>
+    <feature name="m" mapto="RETROK_m"/>
+    <feature name="n" mapto="RETROK_n"/>
+    <feature name="o" mapto="RETROK_o"/>
+    <feature name="p" mapto="RETROK_p"/>
+    <feature name="q" mapto="RETROK_q"/>
+    <feature name="r" mapto="RETROK_r"/>
+    <feature name="s" mapto="RETROK_s"/>
+    <feature name="t" mapto="RETROK_t"/>
+    <feature name="u" mapto="RETROK_u"/>
+    <feature name="v" mapto="RETROK_v"/>
+    <feature name="w" mapto="RETROK_w"/>
+    <feature name="x" mapto="RETROK_x"/>
+    <feature name="y" mapto="RETROK_y"/>
+    <feature name="z" mapto="RETROK_z"/>
+    <feature name="backspace" mapto="RETROK_BACKSPACE"/>
+    <feature name="enter" mapto="RETROK_RETURN"/>
+    <feature name="space" mapto="RETROK_SPACE"/>
+    <feature name="leftalt" mapto="RETROK_LALT"/>
+    <feature name="rightalt" mapto="RETROK_RALT"/>
+    <feature name="leftctrl" mapto="RETROK_LCTRL"/>
+    <feature name="rightctrl" mapto="RETROK_RCTRL"/>
+    <feature name="lshift" mapto="RETROK_LSHIFT"/>
+    <feature name="rshift" mapto="RETROK_RSHIFT"/>
+    <!-- TODO: lmeta, rmeta, lsuper, rsuper -->
+  </controller>
+</buttonmap>

--- a/game.libretro.fuse/resources/buttonmap.xml
+++ b/game.libretro.fuse/resources/buttonmap.xml
@@ -52,8 +52,11 @@
     <feature name="rightalt" mapto="RETROK_RALT"/>
     <feature name="leftctrl" mapto="RETROK_LCTRL"/>
     <feature name="rightctrl" mapto="RETROK_RCTRL"/>
-    <feature name="lshift" mapto="RETROK_LSHIFT"/>
-    <feature name="rshift" mapto="RETROK_RSHIFT"/>
-    <!-- TODO: lmeta, rmeta, lsuper, rsuper -->
+    <feature name="leftshift" mapto="RETROK_LSHIFT"/>
+    <feature name="rightshift" mapto="RETROK_RSHIFT"/>
+    <feature name="leftmeta" mapto="RETROK_LMETA"/>
+    <feature name="rightmeta" mapto="RETROK_RMETA"/>
+    <feature name="leftsuper" mapto="RETROK_LSUPER"/>
+    <feature name="rightsuper" mapto="RETROK_RSUPER"/>
   </controller>
 </buttonmap>

--- a/game.libretro.fuse/resources/topology.xml
+++ b/game.libretro.fuse/resources/topology.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<logicaltopology>
+  <port type="keyboard">
+    <accepts controller="game.controller.keyboard"/>
+  </port>
+  <port type="controller" id="1">
+    <accepts controller="game.controller.atari.2600"/>
+  </port>
+  <port type="controller" id="2">
+    <accepts controller="game.controller.atari.2600"/>
+  </port>
+</logicaltopology>


### PR DESCRIPTION
Data from Fuse source:

buttonmap: https://github.com/libretro/fuse-libretro/blob/master/src/compat/ui.c

topology: https://github.com/libretro/fuse-libretro/blob/master/src/libretro.c

TODO: Fix Atari 2600 support

TODO: Support more controllers instead of using `game.controller.atari.2600`

TODO: Support Sinclair keyboard instead of using `game.controller.keyboard`
  