### PR TITLE
Add zip as extension

### DIFF
--- a/game.libretro.fuse/addon.xml.in
+++ b/game.libretro.fuse/addon.xml.in
@@ -10,7 +10,7 @@
 	<extension point="kodi.gameclient"
 			library_@PLATFORM@="@LIBRARY_FILENAME@">
 		<platforms>spectrum</platforms>
-		<extensions>tzx|tap|z80|rzx|scl|trd|dsk</extensions>
+		<extensions>tzx|tap|z80|rzx|scl|trd|dsk|zip</extensions>
 		<supports_vfs>true</supports_vfs>
 		<supports_standalone>false</supports_standalone>
 		<requires_opengl>false</requires_opengl>


### PR DESCRIPTION
Tested with Kodi v19 by manually editing the addon.xml and adding zip as an acceptable extension. Game loads without issue:
```
GAME: ------------------------------------
GAME: Loaded DLL for game.libretro.fuse
GAME: Client: Sinclair - ZX Spectrum (Fuse) at version 1.6.0.13
GAME: Valid extensions: .rzx .scl .tap .trd .tzx .z80 .zip
GAME: Supports VFS:                  yes
GAME: Supports standalone execution: no
GAME: ------------------------------------
RetroPlayer[INPUT]: Initializing input
PERIPHERALS: Event poll handle registered
RetroPlayer[PLAYER]: Opening: /Users/zc/Downloads/robocop3.zip
GameClient: Loading /Users/zc/Downloads/robocop3.zip
AddOnLog: game.libretro.fuse: 
                                                   +------------------------------------------+
                                                   |              FUSE-LIBRETRO               |
                                                   |    ____    _   _   ___   _      ____     |
                                                   |   | __ )  | | | | |_ _| | |    |  _ \    |
                                                   |   |  _ \  | | | |  | |  | |    | | | |   |
                                                   |   | |_) | | |_| |  | |  | |__  | |_| |   |
                                                   |   |____/   \___/  |___| |____| |____/    |
                                                   |                                          |
                                                   | dbc793ec9106485c71c2c9d397c22bbd81c44c63 |
                                                   +------------------------------------------+
                                                   
                                                   
AddOnLog: game.libretro.fuse: uidisplay_init(320, 240)
                                                   
AddOnLog: game.libretro.fuse: Checking if "/48.rom" exists
                                                   
AddOnLog: game.libretro.fuse: Opened "/48.rom" from memory
                                                   
Skipped 1 duplicate messages..
AddOnLog: game.libretro.fuse: Opened "*.z80" from memory
                                                   
AddOnLog: game.libretro.fuse: uidisplay_init(320, 240)
                                                   
AddOnLog: game.libretro.fuse: Checking if "/128-0.rom" exists
                                                   
AddOnLog: game.libretro.fuse: Opened "/128-0.rom" from memory
                                                   
Skipped 1 duplicate messages..
AddOnLog: game.libretro.fuse: Checking if "/128-1.rom" exists
                                                   
AddOnLog: game.libretro.fuse: Opened "/128-1.rom" from memory
                                                   
Skipped 1 duplicate messages..
AddOnLog: game.libretro.fuse: Checking if "*.pok" exists
                                                   
AddOnLog: game.libretro.fuse: Opened "*.pok" from memory
                                                   
AddOnLog: game.libretro.fuse: fuse_write_snapshot("dummy.szx", 0x7fcbc7659000, 131392)
                                                   
GAME: ---------------------------------------
GAME: Game loop:      true
GAME: FPS:            50.000000
GAME: Sample Rate:    44100.000000
GAME: Region:         PAL
GAME: Savestate size: 131392
GAME: ---------------------------------------
AddOnLog: peripheral.joystick: Loaded device "8Bitdo Zero GamePad" with 2 controller profiles and 20 total features

```